### PR TITLE
Fixed typo in source counts equation

### DIFF
--- a/DMTN-296.tex
+++ b/DMTN-296.tex
@@ -46,10 +46,11 @@ We describe several avenues toward assessing the depth of LSST observations usin
 % Fields: VERSION, DATE, DESCRIPTION, OWNER NAME.
 % See LPM-51 for version number policy.
 \setDocChangeRecord{%
+  \addtohist{3}{2025-11-11}{Fixed typo in source counts equation.}{Alex Drlica-Wagner}
   \addtohist{2}{2024-11-29}{Addressing review comments.}{Alex Drlica-Wagner}
   \addtohist{1}{2024-10-16}{First complete draft.}{Alex Drlica-Wagner}
 }
-\setDocDate{2024-11-29}
+\setDocDate{2025-11-11}
 
 \begin{document}
 
@@ -135,7 +136,7 @@ it can be seen that
 Solving for the positive root of the quadratic SNR equation for $C$, it can be shown that the source counts can be expressed as,
 \begin{equation}
     \label{eqn:counts}
-    C(SNR, n_{\rm eff}, B, \sigma_{\rm instr}) = \frac{(SNR)^2}{2g} + \left( \frac{(SNR)^4}{4g} + (SNR)^2 \sigma_{\rm tot}^2 n_{\rm eff}  \right),
+    C(SNR, n_{\rm eff}, B, \sigma_{\rm instr}) = \frac{(SNR)^2}{2g} + \left( \frac{(SNR)^4}{4g^2} + (SNR)^2 \sigma_{\rm tot}^2 n_{\rm eff}  \right),
 \end{equation}
 where we have defined $\sigma_{\rm tot}^2 = (B/g + \sigma_{\rm instr}^2)$ to be the variance coming from background sources (i.e., the sky and instrument read noise).
 The limiting magnitude can then be determined as,

--- a/acronyms.tex
+++ b/acronyms.tex
@@ -11,7 +11,6 @@ DR2 & Data Release 2 \\\hline
 HSC & Hyper Suprime-Cam \\\hline
 LSE & LSST Systems Engineering (Document Handle) \\\hline
 LSR & LSST System Requirements; LSE-29 \\\hline
-LSS & Large Scale Structure \\\hline
 LSST & Legacy Survey of Space and Time (formerly Large Synoptic Survey Telescope) \\\hline
 OpSim & Operations Simulation \\\hline
 PDR2 & Public Data Release 2 (HSC) \\\hline

--- a/local.bib
+++ b/local.bib
@@ -1,14 +1,3 @@
-@Misc{LSE-40,
-    author = "{Ivezi\'{c}}, \v{Z}eljko and {Jones}, Lynne and {Lupton}, Robert",
-    title = "{Photon Rates and SNR Calculations}",
-    year = "2010",
-    month = "May",
-    publisher = "Vera C. Rubin Observatory",
-    url = "https://ls.st/LSE-40",
-    note = "Vera C. Rubin Observatory LSE-40",
-    handle = "LSE-40"
-}
-
 @ARTICLE{Rykoff:2015,
        author = {{Rykoff}, E.~S. and {Rozo}, E. and {Keisler}, R.},
         title = "{Assessing Galaxy Limiting Magnitudes in Large Optical Surveys}",


### PR DESCRIPTION
Fixed an issue in the gain factor in the source counts equation (Eq.9) that had propagated from LSE-40. See DM-53234 for details.